### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,14 +1,20 @@
 {
-    "perl" : "6.c",
-    "name" : "App::Uni",
-    "version" : "0.9.2",
-    "description" : "command-line utility to find or display Unicode characters",
-    "authors" : [ "Will 'Coke' Coleda" ],
-    "provides" : { 
-        "App::Uni" : "lib/App/Uni.pm"
-    },
-    "depends" : [ ],
-    "resources" : [ ],
-    "source-url" : "git://github.com/coke/p6-uni.git"
+  "name": "App::Uni",
+  "source-url": "git://github.com/coke/p6-uni.git",
+  "perl": "6.c",
+  "resources": [
+    
+  ],
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "App::Uni": "lib/App/Uni.pm"
+  },
+  "version": "0.9.2",
+  "authors": [
+    "Will 'Coke' Coleda"
+  ],
+  "description": "command-line utility to find or display Unicode characters"
 }
-


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license